### PR TITLE
Fix: Correct Lemon Squeezy checkout payload structure

### DIFF
--- a/services/lemonSqueezyService.ts
+++ b/services/lemonSqueezyService.ts
@@ -21,17 +21,24 @@ class LemonSqueezyService {
       throw new Error('Lemon Squeezy client not initialized.');
     }
 
-    const checkout = await createCheckout(storeId!, variantId, {
-      custom: {
-        user_email: userEmail,
-      },
-      checkout_data: {
-        email: userEmail,
-      },
-      redirect_url: successUrl,
-    });
+    try {
+      const checkout = await createCheckout(storeId!, variantId, {
+        checkout_data: {
+          email: userEmail,
+          custom: {
+            user_email: userEmail,
+          },
+        },
+        product_options: {
+          redirect_url: successUrl,
+        },
+      });
 
-    return checkout.data.attributes.url;
+      return checkout.data.attributes.url;
+    } catch (error) {
+      console.error('Error creating checkout session:', error);
+      throw error;
+    }
   }
 
   async getCheckoutSession(checkoutId: string) {


### PR DESCRIPTION
The `createCheckout` call to the Lemon Squeezy API was failing due to an incorrect payload structure. This resulted in a `TypeError` because the API was not returning the expected checkout object with a `url` attribute.

This commit restructures the payload to match the current Lemon Squeezy API requirements:
- The `custom` data object is now nested within the `checkout_data` object.
- The `redirect_url` is now nested within a `product_options` object.

Additionally, a `try...catch` block has been added around the API call to improve error logging and make debugging easier.