### PR TITLE
Fix: Import supabase client in lemonSqueezyService

### DIFF
--- a/services/lemonSqueezyService.ts
+++ b/services/lemonSqueezyService.ts
@@ -1,5 +1,6 @@
 
 import { lemonSqueezySetup, createCheckout, getCheckout } from '@lemonsqueezy/lemonsqueezy.js';
+import { supabase } from './dbService';
 
 const apiKey = import.meta.env.VITE_LEMONSQUEEZY_API_KEY;
 const storeId = import.meta.env.VITE_LEMONSQUEEZY_STORE_ID;


### PR DESCRIPTION
This commit fixes a `ReferenceError: supabase is not defined` that was introduced in the previous commit. The `supabase` client was being used in `lemonSqueezyService.ts` without being imported.

This commit adds the necessary import statement.